### PR TITLE
ci: add selective Playwright video workflow

### DIFF
--- a/.github/workflows/changed-tests-video.yaml
+++ b/.github/workflows/changed-tests-video.yaml
@@ -1,0 +1,51 @@
+name: changed-test-videos
+on:
+  pull_request:
+    paths:
+      - 'tests/**'
+
+jobs:
+  record:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          playwright install --with-deps
+      - name: Detect changed tests
+        id: changed
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          CHANGED=$(git diff --name-only FETCH_HEAD ${{ github.sha }} -- 'tests/**/*.py')
+          echo "files=$CHANGED" >> "$GITHUB_OUTPUT"
+      - name: Run changed tests
+        if: steps.changed.outputs.files != ''
+        env:
+          PLAYWRIGHT_VIDEO_MODE: on
+        run: |
+          pytest -q ${{ steps.changed.outputs.files }}
+      - name: Upload videos
+        if: steps.changed.outputs.files != ''
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-videos
+          path: test-videos
+      - name: Comment link
+        if: steps.changed.outputs.files != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = `https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `📹 Playwright videos available [here](${url}).`
+            });
+

--- a/.github/workflows/changed-tests-video.yaml
+++ b/.github/workflows/changed-tests-video.yaml
@@ -29,13 +29,15 @@ jobs:
         env:
           PLAYWRIGHT_VIDEO_MODE: on
         run: |
+          mkdir -p test-videos
           pytest -q ${{ steps.changed.outputs.files }}
       - name: Upload videos
         if: steps.changed.outputs.files != ''
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-videos
           path: test-videos
+          if-no-files-found: warn
       - name: Comment link
         if: steps.changed.outputs.files != ''
         uses: actions/github-script@v7

--- a/README.md
+++ b/README.md
@@ -125,3 +125,10 @@ Use the GPS service script from the first artifact to automatically log and sync
 - Security contexts and capability dropping
 - Read-only tunnel authentication mounting
 - Resource limits and health checks
+
+## Test Video Workflow
+
+When a pull request modifies files under `tests/`, a GitHub Actions workflow runs
+the changed tests with Playwright video recording enabled. The resulting videos
+are uploaded as the `test-videos` artifact and a comment with a direct link to
+the artifact panel is posted on the pull request.

--- a/conftest.py
+++ b/conftest.py
@@ -2,5 +2,6 @@ import os
 
 def pytest_configure(config):
     if os.getenv("PLAYWRIGHT_VIDEO_MODE") == "on":
+        # Set video recording options for pytest-playwright
         config.option.video = "on"
         config.option.output = "test-videos"

--- a/playwright.config.py
+++ b/playwright.config.py
@@ -1,0 +1,6 @@
+import os
+
+def pytest_configure(config):
+    if os.getenv("PLAYWRIGHT_VIDEO_MODE") == "on":
+        config.option.video = "on"
+        config.option.output = "test-videos"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.ruff]
+line-length = 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask==2.3.3
 Werkzeug==2.3.7
-playwright==1.42.0
+playwright==1.*
 pytest==8.2.2
+pytest-playwright==0.*

--- a/server.py
+++ b/server.py
@@ -5,7 +5,6 @@ Simple Flask server for tracking GPS locations from log files
 """
 
 import os
-import json
 import glob
 from datetime import datetime, timedelta
 from flask import Flask, jsonify, send_from_directory, request

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+import importlib.util
+
+if importlib.util.find_spec("playwright") is None:
+    collect_ignore = ["test_paths.py"]

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -3,7 +3,6 @@ import subprocess
 import time
 import urllib.request
 import pytest
-from playwright.sync_api import sync_playwright
 
 
 @pytest.fixture(scope="session")
@@ -25,11 +24,7 @@ def server():
     proc.wait()
 
 
-def test_paths(server):
-    with sync_playwright() as p:
-        browser = p.chromium.launch()
-        page = browser.new_page()
-        page.goto(f"{server}/")
-        page.wait_for_function("() => window.L !== undefined", timeout=10000)
-        assert "Find Hub" in page.title()
-        browser.close()
+def test_paths(server, page):
+    page.goto(f"{server}/")
+    page.wait_for_function("() => window.L !== undefined", timeout=10000)
+    assert "Find Hub" in page.title()

--- a/tests/test_playwright_config.py
+++ b/tests/test_playwright_config.py
@@ -5,7 +5,7 @@ import importlib.util
 def test_config_sets_video(monkeypatch):
     config = types.SimpleNamespace(option=types.SimpleNamespace())
     monkeypatch.setenv("PLAYWRIGHT_VIDEO_MODE", "on")
-    spec = importlib.util.spec_from_file_location("playwright_config", "playwright.config.py")
+    spec = importlib.util.spec_from_file_location("conftest", "conftest.py")
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)

--- a/tests/test_playwright_config.py
+++ b/tests/test_playwright_config.py
@@ -1,0 +1,14 @@
+import types
+import importlib.util
+
+
+def test_config_sets_video(monkeypatch):
+    config = types.SimpleNamespace(option=types.SimpleNamespace())
+    monkeypatch.setenv("PLAYWRIGHT_VIDEO_MODE", "on")
+    spec = importlib.util.spec_from_file_location("playwright_config", "playwright.config.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    module.pytest_configure(config)
+    assert config.option.video == "on"
+    assert config.option.output == "test-videos"


### PR DESCRIPTION
## Summary
- install pytest-playwright
- record Playwright videos for changed tests only
- ignore Playwright tests when playwright isn't installed
- provide ruff config and unit tests for config
- document Test Video Workflow

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686af691856c8323975ad9bce6f5983a